### PR TITLE
feat: Use Option<SomeType> when type is ["SomeType", "null"]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,4 +690,13 @@ mod tests {
 
         verify_compile("vega", &s);
     }
+
+    #[test]
+    fn optional_type() {
+        let s = include_str!("../tests/option-type.json");
+
+        let s = generate(Some("OptionType"), s).unwrap().to_string();
+
+        assert!(s.contains("pub optional: Option<i64>"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,19 @@ impl<'r> Expander<'r> {
                 }
             }
             return "serde_json::Value".into();
+        } else if typ.type_.len() == 2 {
+            if typ.type_[0] == SimpleTypes::Null || typ.type_[1] == SimpleTypes::Null {
+                let mut ty = typ.clone();
+                ty.type_.retain(|x| *x != SimpleTypes::Null);
+
+                FieldType {
+                    typ: format!("Option<{}>", self.expand_type_(&ty).typ),
+                    attributes: vec![],
+                    default: true,
+                }
+            } else {
+                "serde_json::Value".into()
+            }
         } else if typ.type_.len() == 1 {
             match typ.type_[0] {
                 SimpleTypes::String => {

--- a/tests/option-type.json
+++ b/tests/option-type.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "option-type",
+    "type": "object",
+    "properties": {
+        "non-optional": { "type": "string" },
+        "optional": { "type": ["integer", "null"] }
+    }
+}


### PR DESCRIPTION
Partially addresses #10, but does not handle the `any_of` case. If you'd prefer I address both cases in this PR I can.