### PR TITLE
Handle cases where additionalProperties field is a boolean.

### DIFF
--- a/tests/any-properties.json
+++ b/tests/any-properties.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "any-properties",
+    "type": "object",
+    "additionalProperties": true
+}

--- a/tests/empty-struct.json
+++ b/tests/empty-struct.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "empty-struct",
+    "type": "object",
+    "additionalProperties": false
+}


### PR DESCRIPTION
If it's false, then we always generate a struct, even if it has no
properties. If true, then we can generate a map of String -> Value.