### PR TITLE
Handle arrays where the item type is an object define inline.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,7 @@ impl<'r> Expander<'r> {
                 }
                 SimpleTypes::Array => {
                     let item_type = typ.items.get(0).map_or("serde_json::Value".into(), |item| {
+                        self.current_type = format!("{}Item", self.current_type);
                         self.expand_type_(item).typ
                     });
                     format!("Vec<{}>", item_type).into()
@@ -810,5 +811,17 @@ mod tests {
         assert!(s.contains(
             "pub type AnyProperties = ::std::collections::BTreeMap<String, serde_json::Value>;"
         ));
+    }
+
+    #[test]
+    fn root_array() {
+        let s = include_str!("../tests/root-array.json");
+
+        let s = generate(Some("RootArray"), s).unwrap().to_string();
+
+        verify_compile("root_array", &s);
+
+        assert!(s.contains("pub struct RootArrayItem"));
+        assert!(s.contains("type RootArray = Vec<RootArrayItem>;"));
     }
 }

--- a/tests/root-array.json
+++ b/tests/root-array.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "root-array",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "value": { "type": "integer" }
+        },
+        "additionalProperties": false
+    }
+}


### PR DESCRIPTION
Previously, the generated code would have a name conflict, such as:

```rust
struct Foo {
    // fields
}

type Foo = Vec<Foo>;
```

Now it'll append `Item` to objects that are defined inline:

```rust
struct FooItem {
    // fields
}

type Foo = Vec<FooItem>;
```