### PR TITLE
[Feature] Basic external ref support

### DIFF
--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -68,7 +68,7 @@ pub use schema::{Schema, SimpleTypes};
 use proc_macro2::{Span, TokenStream};
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 
 fn replace_invalid_identifier_chars(s: &str) -> String {
     s.replace(|c: char| !c.is_alphanumeric() && c != '_', "_")
@@ -619,7 +619,7 @@ impl<'r> Expander<'r> {
         }
     }
 
-    fn expand_file_schema_ref(&mut self, abs_file_path: &PathBuf) -> Schema {
+    fn expand_file_schema_ref(&mut self, abs_file_path: &Path) -> Schema {
         if let Some(existing) = self.resolved_schemas.get(abs_file_path) {
             return existing.clone();
         } else {
@@ -648,7 +648,7 @@ impl<'r> Expander<'r> {
             // Merge data from the reffed file Expander to reduce lookups
             self.types.append(&mut reffed_file_expander.types);
             self.resolved_schemas
-                .insert(abs_file_path.clone(), loaded_schema.clone());
+                .insert(abs_file_path.to_owned(), loaded_schema.clone());
             for (resolved_schema_path, resolved_schema) in
                 reffed_file_expander.resolved_schemas.into_iter()
             {
@@ -659,22 +659,22 @@ impl<'r> Expander<'r> {
         }
     }
 
-    fn to_absolute_path(&self, s: &PathBuf) -> PathBuf {
+    fn to_absolute_path(&self, s: &Path) -> PathBuf {
         if s.is_relative() {
             self.schema_directory.join(s)
         } else {
-            s.clone()
+            s.to_owned()
         }
     }
 
-    fn type_from_json_file(p: &PathBuf) -> &str {
+    fn type_from_json_file(p: &Path) -> &str {
         p.file_name()
             .and_then(|f| f.to_str())
             .map(|f| f.trim_end_matches(".json"))
             .expect(&format!("No file name for [{:#?}]", p.as_os_str()))
     }
 
-    fn is_resolved_ref_path(&self, p: &PathBuf) -> bool {
+    fn is_resolved_ref_path(&self, p: &Path) -> bool {
         self.resolved_schemas
             .get(&self.to_absolute_path(p))
             .is_some()

--- a/schemafy_lib/tests/test.rs
+++ b/schemafy_lib/tests/test.rs
@@ -1,15 +1,12 @@
 use schemafy_lib::Expander;
+use std::path::PathBuf;
 
 #[test]
 fn schema() {
     let json = std::fs::read_to_string("src/schema.json").expect("Read schema JSON file");
 
     let schema = serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err));
-    let mut expander = Expander::new(
-        Some("Schema"),
-        "UNUSED",
-        &schema,
-    );
-    
+    let mut expander = Expander::new(Some("Schema"), "UNUSED", &schema, PathBuf::from("src"));
+
     expander.expand(&schema);
 }

--- a/schemafy_lib/tests/test.rs
+++ b/schemafy_lib/tests/test.rs
@@ -1,12 +1,23 @@
 use schemafy_lib::Expander;
+use std::cell::RefCell;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 #[test]
 fn schema() {
     let json = std::fs::read_to_string("src/schema.json").expect("Read schema JSON file");
 
-    let schema = serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err));
-    let mut expander = Expander::new(Some("Schema"), "UNUSED", &schema, PathBuf::from("src"));
+    let schema = Rc::new(RefCell::new(
+        serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err)),
+    ));
+    let mut expander = Expander::new(
+        Some("Schema"),
+        "UNUSED",
+        schema.clone(),
+        PathBuf::from("src"),
+    );
 
-    expander.expand(&schema);
+    let schema_ref = &schema.borrow();
+
+    expander.expand(schema_ref);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,24 @@ impl<'a> GenerateBuilder<'a> {
             input_file
         };
 
-        let json = std::fs::read_to_string(&input_path)
-            .unwrap_or_else(|err| panic!("Unable to read `{}`: {}", input_path.to_string_lossy(), err));
+        let input_dir = input_path
+            .parent()
+            .expect(&format!(
+                "Could not detect directory of file: {}",
+                def.input_file.value()
+            ))
+            .to_owned();
+
+        let json = std::fs::read_to_string(&input_path).unwrap_or_else(|err| {
+            panic!("Unable to read `{}`: {}", input_path.to_string_lossy(), err)
+        });
 
         let schema = serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err));
         let mut expander = Expander::new(
             self.root_name.as_ref().map(|s| &**s),
             self.schemafy_path,
             &schema,
+            input_dir,
         );
         expander.expand(&schema).into()
     }

--- a/tests/ref/nested-ref-type.json
+++ b/tests/ref/nested-ref-type.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "nested-ref-type",
+  "type": "object",
+  "required": [
+    "title",
+    "person"
+  ],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "person": {
+      "$ref": "../reffing-reffed-type.json"
+    }
+  }
+}

--- a/tests/reffed-type.json
+++ b/tests/reffed-type.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "reffed-type",
+  "type": "object",
+  "required": [
+    "name"
+  ],
+  "definitions": {
+    "address": {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/reffing-reffed-type.json
+++ b/tests/reffing-reffed-type.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "reffing-reffed-type",
+  "type": "object",
+  "required": [
+    "name",
+    "address",
+    "age"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "address": {
+      "$ref": "reffed-type.json#/definitions/address"
+    },
+    "age": {
+      "type": "integer"
+    }
+  }
+}

--- a/tests/reffing-type.json
+++ b/tests/reffing-type.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "reffing-type",
+  "type": "object",
+  "required": [
+    "values",
+    "address",
+    "person",
+    "nested"
+  ],
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "reffed-type.json"
+      }
+    },
+    "address": {
+      "$ref": "reffed-type.json#/definitions/address"
+    },
+    "person": {
+      "$ref": "reffing-reffed-type.json"
+    },
+    "nested": {
+      "$ref": "ref/nested-ref-type.json"
+    }
+  }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -83,3 +83,28 @@ fn root_array() {
     let a = RootArray::default();
     let _: Option<&RootArrayItem> = a.get(0);
 }
+
+schemafy::schemafy!(
+    root: ReffingType
+    "tests/reffing-type.json"
+);
+
+#[test]
+fn reffing_type() {
+    let os: Option<ReffingType> = None;
+    if let Some(os) = os {
+        // reffed array type
+        let _: String = os.values[0].name;
+        // reffed type
+        let _: String = os.address.value;
+        let _: String = os.person.name;
+        // double reffed field
+        let _: String = os.person.address.value;
+        let _: i64 = os.person.age;
+        // nested type
+        let _: String = os.nested.title;
+        // nested double ref field
+        let _: String = os.nested.person.address.value;
+        let _: i64 = os.nested.person.age;
+    }
+}


### PR DESCRIPTION
Closes #3 

**tl;dr** Add basic support for "external" `$ref` fields that point to files.

When expanding fields, if field's ref is pointing to a `.json` file, resolve it, and merge all the types it references into the current parent Expander.

The changes in this PR do this by:
* Adding field to Expander that holds the directory of the file from which its Schema is derived; this is re-used for reading relative referenced files.
* When expanding a field that references an external file,  create a child Expander to expand the referenced Schema and merging its data (types and further referenced Schemas) into the current one. Do this recursively.
* Maybe using a tad too many `clone(`)s...

To be honest, I need this for another project I plan on working on, so mostly hacked around until the tests passed without paying too much attention to efficiency. Here to learn so suggestions are welcome :)

Things not handled thus far:

* Circular dependencies (compiler stack overflows)
* Namespacing of types (model name clashes just fail the compile)
