### PR TITLE
[Feature] Basic external ref support redux

### DIFF
--- a/schemafy_lib/Cargo.toml
+++ b/schemafy_lib/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["rc"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 syn = "1.0"
+indexmap = "1.4"
 
 Inflector = "0.11"
 

--- a/schemafy_lib/Cargo.toml
+++ b/schemafy_lib/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 proc-macro2 = "1.0"
 quote = "1.0"
 schemafy_core = { version = "0.5.0", path = "../schemafy_core" } # VERSION_TAG
-serde = "1.0"
+serde = { version = "1.0", features = ["rc"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 syn = "1.0"

--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -68,7 +68,7 @@ pub use schema::{Schema, SimpleTypes};
 use proc_macro2::{Span, TokenStream};
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 
 fn replace_invalid_identifier_chars(s: &str) -> String {
     s.replace(|c: char| !c.is_alphanumeric() && c != '_', "_")
@@ -619,7 +619,7 @@ impl<'r> Expander<'r> {
         }
     }
 
-    fn expand_file_schema_ref(&mut self, abs_file_path: &PathBuf) -> Schema {
+    fn expand_file_schema_ref(&mut self, abs_file_path: &Path) -> Schema {
         if let Some(existing) = self.resolved_schemas.get(abs_file_path) {
             return existing.clone();
         } else {
@@ -648,7 +648,7 @@ impl<'r> Expander<'r> {
             // Merge data from the reffed file Expander to reduce lookups
             self.types.append(&mut reffed_file_expander.types);
             self.resolved_schemas
-                .insert(abs_file_path.clone(), loaded_schema.clone());
+                .insert(abs_file_path.to_owned(), loaded_schema.clone());
             for (resolved_schema_path, resolved_schema) in
                 reffed_file_expander.resolved_schemas.into_iter()
             {
@@ -659,22 +659,22 @@ impl<'r> Expander<'r> {
         }
     }
 
-    fn to_absolute_path(&self, s: &PathBuf) -> PathBuf {
+    fn to_absolute_path(&self, s: &Path) -> PathBuf {
         if s.is_relative() {
             self.schema_directory.join(s)
         } else {
-            s.clone()
+            s.to_owned()
         }
     }
 
-    fn type_from_json_file(p: &PathBuf) -> &str {
+    fn type_from_json_file(p: &Path) -> &str {
         p.file_name()
             .and_then(|f| f.to_str())
             .map(|f| f.trim_end_matches(".json"))
             .expect(&format!("No file name for [{:#?}]", p.as_os_str()))
     }
 
-    fn is_resolved_ref_path(&self, p: &PathBuf) -> bool {
+    fn is_resolved_ref_path(&self, p: &Path) -> bool {
         self.resolved_schemas
             .get(&self.to_absolute_path(p))
             .is_some()

--- a/schemafy_lib/src/schema.rs
+++ b/schemafy_lib/src/schema.rs
@@ -1,6 +1,6 @@
 pub type PositiveInteger = i64;
 pub type PositiveIntegerDefault0 = serde_json::Value;
-pub type SchemaArray = Vec<Schema>;
+pub type SchemaArray = Vec<::std::rc::Rc<Schema>>;
 #[serde(rename = "simpleTypes")]
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub enum SimpleTypes {
@@ -36,7 +36,7 @@ pub struct Schema {
     pub any_of: Option<SchemaArray>,
     pub default: Option<serde_json::Value>,
     #[serde(default)]
-    pub definitions: ::std::collections::BTreeMap<String, Schema>,
+    pub definitions: ::std::collections::BTreeMap<String, ::std::rc::Rc<Schema>>,
     pub dependencies: Option<::std::collections::BTreeMap<String, serde_json::Value>>,
     pub description: Option<String>,
     #[serde(rename = "enum")]
@@ -48,7 +48,7 @@ pub struct Schema {
     pub id: Option<String>,
     #[serde(default)]
     #[serde(with = "::schemafy_core::one_or_many")]
-    pub items: Vec<Schema>,
+    pub items: Vec<::std::rc::Rc<Schema>>,
     #[serde(rename = "maxItems")]
     pub max_items: Option<PositiveInteger>,
     #[serde(rename = "maxLength")]
@@ -65,15 +65,15 @@ pub struct Schema {
     pub minimum: Option<f64>,
     #[serde(rename = "multipleOf")]
     pub multiple_of: Option<f64>,
-    pub not: Option<Box<Schema>>,
+    pub not: Option<::std::rc::Rc<Schema>>,
     #[serde(rename = "oneOf")]
     pub one_of: Option<SchemaArray>,
     pub pattern: Option<String>,
     #[serde(default)]
     #[serde(rename = "patternProperties")]
-    pub pattern_properties: ::std::collections::BTreeMap<String, Schema>,
+    pub pattern_properties: ::std::collections::BTreeMap<String, ::std::rc::Rc<Schema>>,
     #[serde(default)]
-    pub properties: ::std::collections::BTreeMap<String, Schema>,
+    pub properties: ::std::collections::BTreeMap<String, ::std::rc::Rc<Schema>>,
     pub required: Option<StringArray>,
     pub title: Option<String>,
     #[serde(default)]

--- a/schemafy_lib/tests/test.rs
+++ b/schemafy_lib/tests/test.rs
@@ -1,15 +1,12 @@
 use schemafy_lib::Expander;
+use std::path::PathBuf;
 
 #[test]
 fn schema() {
     let json = std::fs::read_to_string("src/schema.json").expect("Read schema JSON file");
 
     let schema = serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err));
-    let mut expander = Expander::new(
-        Some("Schema"),
-        "UNUSED",
-        &schema,
-    );
-    
+    let mut expander = Expander::new(Some("Schema"), "UNUSED", &schema, PathBuf::from("src"));
+
     expander.expand(&schema);
 }

--- a/schemafy_lib/tests/test.rs
+++ b/schemafy_lib/tests/test.rs
@@ -1,12 +1,20 @@
-use schemafy_lib::Expander;
+use schemafy_lib::{Expander, Schema};
 use std::path::PathBuf;
+use std::rc::Rc;
 
 #[test]
 fn schema() {
     let json = std::fs::read_to_string("src/schema.json").expect("Read schema JSON file");
 
-    let schema = serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err));
-    let mut expander = Expander::new(Some("Schema"), "UNUSED", &schema, PathBuf::from("src"));
+    let schema: Rc<Schema> =
+        Rc::new(serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err)));
+    let mut expander = Expander::new(
+        Some("Schema"),
+        "UNUSED",
+        schema.clone(),
+        PathBuf::from("src"),
+        &None,
+    );
 
-    expander.expand(&schema);
+    expander.expand(schema);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,24 @@ impl<'a> GenerateBuilder<'a> {
             input_file
         };
 
-        let json = std::fs::read_to_string(&input_path)
-            .unwrap_or_else(|err| panic!("Unable to read `{}`: {}", input_path.to_string_lossy(), err));
+        let input_dir = input_path
+            .parent()
+            .expect(&format!(
+                "Could not detect directory of file: {}",
+                def.input_file.value()
+            ))
+            .to_owned();
+
+        let json = std::fs::read_to_string(&input_path).unwrap_or_else(|err| {
+            panic!("Unable to read `{}`: {}", input_path.to_string_lossy(), err)
+        });
 
         let schema = serde_json::from_str(&json).unwrap_or_else(|err| panic!("{}", err));
         let mut expander = Expander::new(
             self.root_name.as_ref().map(|s| &**s),
             self.schemafy_path,
             &schema,
+            input_dir,
         );
         expander.expand(&schema).into()
     }

--- a/tests/ref/nested-ref-type.json
+++ b/tests/ref/nested-ref-type.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "nested-ref-type",
+  "type": "object",
+  "required": [
+    "title",
+    "person"
+  ],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "person": {
+      "$ref": "../reffing-reffed-type.json"
+    }
+  }
+}

--- a/tests/reffed-type.json
+++ b/tests/reffed-type.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "reffed-type",
+  "type": "object",
+  "required": [
+    "name"
+  ],
+  "definitions": {
+    "address": {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/reffing-reffed-type.json
+++ b/tests/reffing-reffed-type.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "reffing-reffed-type",
+  "type": "object",
+  "required": [
+    "name",
+    "address",
+    "age"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "address": {
+      "$ref": "reffed-type.json#/definitions/address"
+    },
+    "age": {
+      "type": "integer"
+    }
+  }
+}

--- a/tests/reffing-type.json
+++ b/tests/reffing-type.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "reffing-type",
+  "type": "object",
+  "required": [
+    "values",
+    "address",
+    "person",
+    "nested"
+  ],
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "reffed-type.json"
+      }
+    },
+    "address": {
+      "$ref": "reffed-type.json#/definitions/address"
+    },
+    "person": {
+      "$ref": "reffing-reffed-type.json"
+    },
+    "nested": {
+      "$ref": "ref/nested-ref-type.json"
+    }
+  }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -83,3 +83,28 @@ fn root_array() {
     let a = RootArray::default();
     let _: Option<&RootArrayItem> = a.get(0);
 }
+
+schemafy::schemafy!(
+    root: ReffingType
+    "tests/reffing-type.json"
+);
+
+#[test]
+fn reffing_type() {
+    let os: Option<ReffingType> = None;
+    if let Some(os) = os {
+        // reffed array type
+        let _: String = os.values[0].name;
+        // reffed type
+        let _: String = os.address.value;
+        let _: String = os.person.name;
+        // double reffed field
+        let _: String = os.person.address.value;
+        let _: i64 = os.person.age;
+        // nested type
+        let _: String = os.nested.title;
+        // nested double ref field
+        let _: String = os.nested.person.address.value;
+        let _: i64 = os.nested.person.age;
+    }
+}


### PR DESCRIPTION
This is another attempt at https://github.com/Marwes/schemafy/pull/31, but puts `Rc`s in the models generated from the JsonSchema spec.

 @Marwes I *think* this is closer what you meant in https://github.com/Marwes/schemafy/pull/31#pullrequestreview-434342551 vs what was done in https://github.com/Marwes/schemafy/pull/31/commits/18a55f5783025d9c20522770a4d7b6facd679a83

