### PR TITLE
Fix when map property starts with a number

### DIFF
--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -71,8 +71,17 @@ fn replace_invalid_identifier_chars(s: &str) -> String {
     s.replace(|c: char| !c.is_alphanumeric() && c != '_', "_")
 }
 
+fn replace_numeric_start(s: &str) -> String {
+    if s.chars().next().map(|c| c.is_numeric()).unwrap_or(false) {
+        format!("_{}", s)
+    } else {
+        s.to_string()
+    }
+}
+
 pub fn str_to_ident(s: &str) -> syn::Ident {
     let s = replace_invalid_identifier_chars(s);
+    let s = replace_numeric_start(&s);
     let keywords = [
         "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn",
         "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref",
@@ -306,7 +315,9 @@ impl<'r> Expander<'r> {
         } else {
             s.split('/').last().expect("Component")
         };
-        replace_invalid_identifier_chars(&s.to_pascal_case())
+        let s = &s.to_pascal_case();
+        let s = replace_invalid_identifier_chars(&s);
+        replace_numeric_start(&s)
     }
 
     fn schema(&self, schema: &'r Schema) -> Cow<'r, Schema> {

--- a/schemafy_lib/src/schema.json
+++ b/schemafy_lib/src/schema.json
@@ -148,7 +148,11 @@
         "allOf": { "$ref": "#/definitions/schemaArray" },
         "anyOf": { "$ref": "#/definitions/schemaArray" },
         "oneOf": { "$ref": "#/definitions/schemaArray" },
-        "not": { "$ref": "#" }
+        "not": { "$ref": "#" },
+        "0": { "$ref": "#" },
+        "numericalEnum": {
+            "enum": [ "0", "1", "2", "3", "4", "5", "6" ]
+        }
     },
     "dependencies": {
         "exclusiveMaximum": [ "maximum" ],

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,6 +12,7 @@ pub type PositiveInteger = i64 ; pub type PositiveIntegerDefault0 = serde_json
 {
     # [serde(rename = "$ref")] pub _ref : Option < String >, #
     [serde(rename = "$schema")] pub _schema : Option < String >, #
+    [serde(rename = "0")] pub _0 : Option < Box < Schema >>, #
     [serde(rename = "additionalItems")] pub additional_items : Option <
     serde_json :: Value >, # [serde(rename = "additionalProperties")] pub
     additional_properties : Option < serde_json :: Value >, #
@@ -36,14 +37,15 @@ pub type PositiveInteger = i64 ; pub type PositiveIntegerDefault0 = serde_json
     : Option < PositiveIntegerDefault0 >, # [serde(rename = "minProperties")]
     pub min_properties : Option < PositiveIntegerDefault0 >, pub minimum :
     Option < f64 >, # [serde(rename = "multipleOf")] pub multiple_of : Option
-    < f64 >, pub not : Option < Box < Schema >>, # [serde(rename = "oneOf")]
-    pub one_of : Option < SchemaArray >, pub pattern : Option < String >, #
-    [serde(default)] # [serde(rename = "patternProperties")] pub
-    pattern_properties : :: std :: collections :: BTreeMap < String, Schema >,
-    # [serde(default)] pub properties : :: std :: collections :: BTreeMap <
-    String, Schema >, pub required : Option < StringArray >, pub title :
-    Option < String >, # [serde(default)] #
-    [serde(with = "::schemafy_core::one_or_many")] # [serde(rename = "type")]
-    pub type_ : Vec < SimpleTypes >, # [serde(rename = "uniqueItems")] pub
-    unique_items : Option < bool >
+    < f64 >, pub not : Option < Box < Schema >>, #
+    [serde(rename = "numericalEnum")] pub numerical_enum : Option < serde_json
+    :: Value >, # [serde(rename = "oneOf")] pub one_of : Option < SchemaArray
+    >, pub pattern : Option < String >, # [serde(default)] #
+    [serde(rename = "patternProperties")] pub pattern_properties : :: std ::
+    collections :: BTreeMap < String, Schema >, # [serde(default)] pub
+    properties : :: std :: collections :: BTreeMap < String, Schema >, pub
+    required : Option < StringArray >, pub title : Option < String >, #
+    [serde(default)] # [serde(with = "::schemafy_core::one_or_many")] #
+    [serde(rename = "type")] pub type_ : Vec < SimpleTypes >, #
+    [serde(rename = "uniqueItems")] pub unique_items : Option < bool >
 }


### PR DESCRIPTION
Currently the macro panics is a map property starts with a number, because it is illegal in Rust.

The fix prepends such fields with an underscore and adds a test case for this.

~CI is failing, but should be fixed by https://github.com/Marwes/schemafy/pull/34~ Fixed

~Fxes https://github.com/Marwes/schemafy/issues/28~ Sorry, the issue is about slightly different case