### PR TITLE
Add #[skip_serializing_if="Option::is_none"] to optional attributes.

### DIFF
--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -360,7 +360,8 @@ impl<'r> Expander<'r> {
             result.typ = format!("Box<{}>", result.typ)
         }
         if !required && !result.default {
-            result.typ = format!("Option<{}>", result.typ)
+            result.typ = format!("Option<{}>", result.typ);
+            result.attributes.push("skip_serializing_if=\"Option::is_none\"".into());
         }
         result
     }


### PR DESCRIPTION
Fixes #17.