### PR TITLE
Add keywords to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 description = "Generates serializeable Rust types from a json schema"
 license = "MIT"
-
+keywords = ["json-schema", "code-generation"]
 repository = "https://github.com/Marwes/schemafy"
 documentation = "https://docs.rs/schemafy"
 


### PR DESCRIPTION
This looks like a great project, but it took me a while to find it, because it doesn't appear in this list:
https://crates.io/keywords/json-schema

I also added code-generation as a  keyword
https://crates.io/keywords/code-generation

https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field