### PR TITLE
Test suite improvements

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,11 @@
-#[cfg(feature = "internal-regenerate")]
 fn main() {
-    let schema_path = "schemafy_lib/src/schema.json";
-    schemafy_lib::Generator::builder()
-        .with_root_name_str("Schema")
-        .with_input_file(schema_path)
-        .build()
-        .generate_to_file("schemafy_lib/src/schema.rs")
-        .unwrap();
+    if cfg!(feature = "internal-regenerate") {
+        let schema_path = "schemafy_lib/src/schema.json";
+        schemafy_lib::Generator::builder()
+            .with_root_name_str("Schema")
+            .with_input_file(schema_path)
+            .build()
+            .generate_to_file("schemafy_lib/src/schema.rs")
+            .unwrap();
+    }
 }
-
-#[cfg(not(feature = "internal-regenerate"))]
-fn main() {}

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 cargo build --features internal-regenerate
 
-rm -rf tests/test_suite
 cargo run --bin generate-tests --features="generate-tests"
 cargo fmt --all
 cargo test --all 


### PR DESCRIPTION
+ Print generated schema instead of macro
+ Do not create empty files
+ In generator, use Path for filepath
+ Whitelist a few ref tests
+ Small cleanup and polishing

This should fix issues like reported in https://github.com/Marwes/schemafy/issues/46.
Now the generated types are clearly visible in the test files, so one doesn't need to use `cargo-expand`