### PR TITLE
Handle underscore fields

### DIFF
--- a/schemafy_lib/Cargo.toml
+++ b/schemafy_lib/Cargo.toml
@@ -19,6 +19,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 syn = "1.0"
+uriparse = "0.6"
 
 Inflector = "0.11"
 

--- a/schemafy_lib/tests/test.rs
+++ b/schemafy_lib/tests/test.rs
@@ -21,15 +21,9 @@ fn test_str_to_ident() {
         Ident::new("normalField", Span::call_site())
     );
 
-    assert_eq!(
-        str_to_ident("ref"),
-        Ident::new("ref_", Span::call_site())
-    );
+    assert_eq!(str_to_ident("ref"), Ident::new("ref_", Span::call_site()));
 
-    assert_eq!(
-        str_to_ident(""),
-        Ident::new("empty_", Span::call_site())
-    );
+    assert_eq!(str_to_ident(""), Ident::new("empty_", Span::call_site()));
     assert_eq!(
         str_to_ident("_"),
         Ident::new("underscore_", Span::call_site())
@@ -39,10 +33,7 @@ fn test_str_to_ident() {
         Ident::new("underscore_", Span::call_site())
     );
 
-    assert_eq!(
-        str_to_ident("_7_"),
-        Ident::new("_7_", Span::call_site())
-    );
+    assert_eq!(str_to_ident("_7_"), Ident::new("_7_", Span::call_site()));
     assert_eq!(
         str_to_ident("thieves' tools"),
         // only one underscore

--- a/schemafy_lib/tests/test.rs
+++ b/schemafy_lib/tests/test.rs
@@ -9,3 +9,43 @@ fn schema() {
 
     expander.expand(&schema);
 }
+
+#[test]
+fn test_str_to_ident() {
+    use proc_macro2::Span;
+    use schemafy_lib::str_to_ident;
+    use syn::Ident;
+
+    assert_eq!(
+        str_to_ident("normalField"),
+        Ident::new("normalField", Span::call_site())
+    );
+
+    assert_eq!(
+        str_to_ident("ref"),
+        Ident::new("ref_", Span::call_site())
+    );
+
+    assert_eq!(
+        str_to_ident(""),
+        Ident::new("empty_", Span::call_site())
+    );
+    assert_eq!(
+        str_to_ident("_"),
+        Ident::new("underscore_", Span::call_site())
+    );
+    assert_eq!(
+        str_to_ident("__"),
+        Ident::new("underscore_", Span::call_site())
+    );
+
+    assert_eq!(
+        str_to_ident("_7_"),
+        Ident::new("_7_", Span::call_site())
+    );
+    assert_eq!(
+        str_to_ident("thieves' tools"),
+        // only one underscore
+        Ident::new("thieves_tools", Span::call_site())
+    );
+}


### PR DESCRIPTION
And a few other edge cases.

Rust is not happy when there is more than one underscore in a row in a field name. This can happen when transforming a name like `thieves' tools`: one underscore replaces the `'` and the other one the space.

Another edge case is when the field name is just `_`. `.to_snake_case()` will just leave it empty, so it's better to replace is with some placeholder and return early.