### PR TITLE
Don't accumulate types of previous fields in type names

### DIFF
--- a/schemafy_lib/tests/multiple-property-types.json
+++ b/schemafy_lib/tests/multiple-property-types.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "multiple-property-types",
+  "type": "object",
+  "properties": {
+    "A": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "B": {
+            "type": "integer"
+          },
+          "C": {
+            "type": "object",
+            "properties": {
+              "D": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "K": {
+      "type": "object",
+      "properties": {
+        "L": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "M": {
+          "type": "object",
+          "properties": {
+            "N": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "T": {
+      "type": "object",
+      "properties": {
+        "U": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "V": {
+          "type": "object",
+          "properties": {
+            "W": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
After finishing a type expansion, reset `self.current_type` so that the details of the field aren't prepended to type names of future fields.

The test schema currently produces these types:

    Root
    RootItemA
    RootItemAC
    RootItemACK
    RootItemACKItemM
    RootItemACKItemMT
    RootItemACKItemMTItemV

With this change, it produces these types:

    Root
    RootItemA
    RootItemAC
    RootK
    RootKM
    RootT
    RootTV