### PR TITLE
Add support for one_of type

### DIFF
--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -528,7 +528,7 @@ impl<'r> Expander<'r> {
                 let name = schema
                     .id
                     .clone()
-                    .unwrap_or(format!("{}Variant{}", saved_type, i));
+                    .unwrap_or_else(|| format!("{}Variant{}", saved_type, i));
                 if let Some(ref_) = &schema.ref_ {
                     let type_ = self.type_ref(ref_);
                     (format_ident!("{}", &name), format_ident!("{}", &type_))

--- a/src/generate_tests.rs
+++ b/src/generate_tests.rs
@@ -91,9 +91,9 @@ mod _{}_{} {{
                 // on .is_ok(). For the negative test cases, a simple
                 // assert is the best we can do.
                 let assertion = if test.valid {
-                    "let _: Schema = serde_json::from_str(&data).unwrap();"
+                    "let _: Schema = serde_json::from_str(data).unwrap();"
                 } else {
-                    "assert!(serde_json::from_str::<Schema>(&data).is_err());"
+                    "assert!(serde_json::from_str::<Schema>(data).is_err());"
                 };
 
                 test_file.push_str(&format!(

--- a/tests/one-of-types.json
+++ b/tests/one-of-types.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "one-of-types",
+  "type": "object",
+  "oneOf": [
+    {
+      "properties": {
+        "bar": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "bar"
+      ]
+    },
+    {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    }
+  ]
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -120,7 +120,26 @@ schemafy::schemafy!(
 
 #[test]
 fn one_of_parsing() {
-    let _: OneOfSchema = serde_json::from_str(r#"{"bar":2}"#).unwrap();
-    let _: OneOfSchema = serde_json::from_str(r#"{"foo":"baz"}"#).unwrap();
+    let t1: OneOfSchema = serde_json::from_str(r#"{"bar":2}"#).unwrap();
+    assert_eq!(
+        t1,
+        OneOfSchema::OneOfSchemaVariant0(OneOfSchemaVariant0 { bar: 2 })
+    );
+
+    let t2: OneOfSchema = serde_json::from_str(r#"{"foo":"baz"}"#).unwrap();
+    assert_eq!(
+        t2,
+        OneOfSchema::OneOfSchemaVariant1(OneOfSchemaVariant1 {
+            foo: "baz".to_string()
+        })
+    );
+
+    // This should return an error, but serde still parses it
+    let t3: OneOfSchema = serde_json::from_str(r#"{"bar": 2, "foo":"baz"}"#).unwrap();
+    assert_eq!(
+        t3,
+        OneOfSchema::OneOfSchemaVariant0(OneOfSchemaVariant0 { bar: 2 })
+    );
+
     assert!(serde_json::from_str::<OneOfSchema>(r#"{"foo":3}"#).is_err());
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -112,3 +112,15 @@ schemafy::schemafy!(
 
 #[allow(dead_code)]
 fn recursive_types_exist(_: RecursiveTypes) {}
+
+schemafy::schemafy!(
+    root: OneOfSchema
+    "tests/one-of-types.json"
+);
+
+#[test]
+fn one_of_parsing() {
+    let _: OneOfSchema = serde_json::from_str(r#"{"bar":2}"#).unwrap();
+    let _: OneOfSchema = serde_json::from_str(r#"{"foo":"baz"}"#).unwrap();
+    assert!(serde_json::from_str::<OneOfSchema>(r#"{"foo":3}"#).is_err());
+}


### PR DESCRIPTION
This PR adds support for `one_of` field type. It relies on serde's [untagged enums](https://serde.rs/enum-representations.html#untagged) feature, meaning that schemafy will try to guess which enum variant is the most suitable. 

One caveat here is that serde is a bit too eager to find at least one match, so if an object matches several enum variants, the first will be chosen. I see this as a minor thing, since validating incoming JSONs is not a goal of this project. However, this peculiarity breaks negative tests from the Test Suite, so I had to copy-paste the successful scenarios to a regular test file.

Apart from `one_of` feature, this PR also fixes how relative schema paths are resolved. The previous implementation relied on `CARGO_MANIFEST_DIR` env variable, which may not be present in some use cases, e.g. debugging a test using `Debug` button in rust-analyzer. 