### PR TITLE
Small improvements

### DIFF
--- a/schemafy_lib/src/generator.rs
+++ b/schemafy_lib/src/generator.rs
@@ -54,12 +54,14 @@ impl<'a, 'b> Generator<'a, 'b> {
         expander.expand(&schema)
     }
 
-    pub fn generate_to_file(&self, output_file: &str) -> io::Result<()> {
+    pub fn generate_to_file<P: ?Sized + AsRef<Path>>(&self, output_file: &'b P) -> io::Result<()> {
         use std::process::Command;
         let tokens = self.generate();
         let out = tokens.to_string();
         std::fs::write(output_file, &out)?;
-        Command::new("rustfmt").arg(output_file).output()?;
+        Command::new("rustfmt")
+            .arg(output_file.as_ref().as_os_str())
+            .output()?;
         Ok(())
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -121,25 +121,19 @@ schemafy::schemafy!(
 #[test]
 fn one_of_parsing() {
     let t1: OneOfSchema = serde_json::from_str(r#"{"bar":2}"#).unwrap();
-    assert_eq!(
-        t1,
-        OneOfSchema::OneOfSchemaVariant0(OneOfSchemaVariant0 { bar: 2 })
-    );
+    assert_eq!(t1, OneOfSchema::Variant0(OneOfSchemaVariant0 { bar: 2 }));
 
     let t2: OneOfSchema = serde_json::from_str(r#"{"foo":"baz"}"#).unwrap();
     assert_eq!(
         t2,
-        OneOfSchema::OneOfSchemaVariant1(OneOfSchemaVariant1 {
+        OneOfSchema::Variant1(OneOfSchemaVariant1 {
             foo: "baz".to_string()
         })
     );
 
     // This should return an error, but serde still parses it
     let t3: OneOfSchema = serde_json::from_str(r#"{"bar": 2, "foo":"baz"}"#).unwrap();
-    assert_eq!(
-        t3,
-        OneOfSchema::OneOfSchemaVariant0(OneOfSchemaVariant0 { bar: 2 })
-    );
+    assert_eq!(t3, OneOfSchema::Variant0(OneOfSchemaVariant0 { bar: 2 }));
 
     assert!(serde_json::from_str::<OneOfSchema>(r#"{"foo":3}"#).is_err());
 }


### PR DESCRIPTION
- Make `generate_to_file` arguments consistent with others
- Fix a panic when `rename_keyword` is called with an empty prefix (e.g. from `expand_schema` function)
- Handle schema references with filenames at the begging of a link
- `oneOf` fixes:
  - Add field name to an enum name so that it won't clash with a higher type definition
  - Remove enum name from variant names, so that clippy won't complain anymore