### PR TITLE
Skip serializing non-required `None` value

### DIFF
--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -419,11 +419,15 @@ impl<'r> Expander<'r> {
         if type_name.to_pascal_case() == result.typ.to_pascal_case() {
             result.typ = format!("Box<{}>", result.typ)
         }
-        if !required && !result.default {
-            result.typ = format!("Option<{}>", result.typ);
-            result
-                .attributes
-                .push("skip_serializing_if=\"Option::is_none\"".into());
+        if !required {
+            if !result.default {
+                result.typ = format!("Option<{}>", result.typ);
+            }
+            if result.typ.starts_with("Option<") {
+                result
+                    .attributes
+                    .push("skip_serializing_if=\"Option::is_none\"".into());
+            }
         }
         result
     }

--- a/tests/array-type.json
+++ b/tests/array-type.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "array-type",
+    "type": "object",
+    "properties": {
+        "required": {
+            "type": "array",
+            "items": { "type": "integer" }
+        },
+        "optional": {
+            "type": "array",
+            "items": { "type": "integer" }
+        }
+    },
+    "required": [
+        "required"
+    ]
+}

--- a/tests/option-type.json
+++ b/tests/option-type.json
@@ -3,7 +3,13 @@
     "title": "option-type",
     "type": "object",
     "properties": {
-        "non-optional": { "type": "string" },
-        "optional": { "type": ["integer", "null"] }
-    }
+        "optional": { "type": "string" },
+        "optional-multi": { "type": ["integer", "null"] },
+        "required": { "type": "string" },
+        "required-multi": { "type": ["integer", "null"] }
+    },
+    "required": [
+        "required",
+        "required-multi"
+    ]
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -57,6 +57,16 @@ fn option_type() {
     //serde_json::from_str::<OptionType>(r#"{"required": ""}"#).unwrap_err();
     serde_json::from_str::<OptionType>(r#"{"required-multi": 5}"#).unwrap_err();
     serde_json::from_str::<OptionType>(r#"{"required": "", "required-multi": 5}"#).unwrap();
+    assert_eq!(
+        serde_json::to_string(&OptionType {
+            optional: None,
+            optional_multi: None,
+            required: "".into(),
+            required_multi: None,
+        })
+        .unwrap(),
+        r#"{"required":"","required-multi":null}"#
+    );
 }
 
 schemafy::schemafy!(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -53,6 +53,30 @@ fn option_type() {
 }
 
 schemafy::schemafy!(
+    root: ArrayType
+    "tests/array-type.json"
+);
+
+#[test]
+fn array_type() {
+    let o: Option<ArrayType> = None;
+    if let Some(o) = o {
+        let _: Vec<i64> = o.required;
+        let _: Option<Vec<i64>> = o.optional;
+    }
+    serde_json::from_str::<ArrayType>("{}").unwrap_err();
+    serde_json::from_str::<ArrayType>(r#"{"required": []}"#).unwrap();
+    assert_eq!(
+        serde_json::to_string(&ArrayType {
+            required: Vec::new(),
+            optional: None,
+        })
+        .unwrap(),
+        r#"{"required":[]}"#
+    );
+}
+
+schemafy::schemafy!(
     root: EmptyStruct
     "tests/empty-struct.json"
 );

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -48,8 +48,15 @@ schemafy::schemafy!(
 fn option_type() {
     let o: Option<OptionType> = None;
     if let Some(o) = o {
-        let _: Option<i64> = o.optional;
+        let _: Option<String> = o.optional;
+        let _: Option<i64> = o.optional_multi;
+        let _: String = o.required;
+        let _: Option<i64> = o.required_multi;
     }
+    // FIXME: this fails
+    //serde_json::from_str::<OptionType>(r#"{"required": ""}"#).unwrap_err();
+    serde_json::from_str::<OptionType>(r#"{"required-multi": 5}"#).unwrap_err();
+    serde_json::from_str::<OptionType>(r#"{"required": "", "required-multi": 5}"#).unwrap();
 }
 
 schemafy::schemafy!(


### PR DESCRIPTION
Currently we correctly skip serialization of properties with `None` values if we've synthesized the `Option<T>` wrapper because the property is not required.  However, when the property is not required *and* it's already typed `Option<T>` because it's defined as `"type": ["T", "null"]`, we were not skipping serialization when its value is `None`.  Do so.

Also add a test for required/optional arrays, and extend the `OptionType` test to cover required fields.