### PR TITLE
Add `#[serde(deny_unknown_fields)]` when `additionalProperties` is false

### DIFF
--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -608,10 +608,18 @@ impl<'r> Expander<'r> {
         };
         let is_enum = schema.enum_.as_ref().map_or(false, |e| !e.is_empty());
         let type_decl = if is_struct {
+            let serde_deny_unknown = if schema.additional_properties == Some(Value::Bool(false))
+                && schema.pattern_properties.is_empty()
+            {
+                Some(quote! { #[serde(deny_unknown_fields)] })
+            } else {
+                None
+            };
             if default {
                 quote! {
                     #[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
                     #serde_rename
+                    #serde_deny_unknown
                     pub struct #name {
                         #(#fields),*
                     }
@@ -620,6 +628,7 @@ impl<'r> Expander<'r> {
                 quote! {
                     #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
                     #serde_rename
+                    #serde_deny_unknown
                     pub struct #name {
                         #(#fields),*
                     }

--- a/tests/pattern-properties.json
+++ b/tests/pattern-properties.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "pattern-properties",
+    "type": "object",
+    "additionalProperties": false,
+    "patternProperties": {
+        "foo": {
+            "type": "object",
+            "additionalProperties": true
+        }
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -178,3 +178,23 @@ fn one_of_parsing() {
 
     assert!(serde_json::from_str::<OneOfSchema>(r#"{"foo":3}"#).is_err());
 }
+
+schemafy::schemafy!(
+    root: PatternProperties
+    "tests/pattern-properties.json"
+);
+
+#[test]
+fn unknown_fields() {
+    // empty struct with additionalProperties: false
+    serde_json::from_str::<EmptyStruct>(r#"{"zzz": 5}"#).unwrap_err();
+    // non-empty struct with additionalProperties: false
+    serde_json::from_str::<RootArrayItem>(r#"{"zzz": 5}"#).unwrap_err();
+    // empty struct with additionalProperties: true
+    serde_json::from_str::<AnyProperties>(r#"{"zzz": 5}"#).unwrap();
+    // empty struct with additionalProperties: false and patternProperties
+    // non-empty
+    serde_json::from_str::<PatternProperties>(r#"{"zzz": 5}"#).unwrap();
+    // non-empty struct with additionalProperties unspecified
+    serde_json::from_str::<ArrayType>(r#"{"required": [], "zzz": 5}"#).unwrap();
+}


### PR DESCRIPTION
If a schema sets `additionalProperties` to false, it's asking us to reject structs with unknown fields.  If it also doesn't define any `patternProperties`, the explicitly enumerated set of properties is exhaustive, so we can safely set `#[serde(deny_unknown_fields)]`.