### PR TITLE
Add a command line flag to prevent writing 'deny_unknown_fields'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 use anyhow::{anyhow, bail, Context, Result};
-use schemafy_lib::Generator;
+use schemafy_lib::{Generator, GeneratorOptions};
 use structopt::StructOpt;
 use tempfile::NamedTempFile;
 
@@ -18,16 +18,22 @@ struct Opts {
     output: Option<String>,
     /// JSON schema file
     schema_path: String,
+    /// Flag to allow new fields from the server.
+    #[structopt(long)]
+    allow_unknown_fields: bool,
 }
 
 pub fn main() -> Result<()> {
     let opts = Opts::from_args();
-
+    let generator_options = GeneratorOptions {
+        deny_unknown_fields: !opts.allow_unknown_fields,
+    };
     // generate the Rust code
     let mut generated_file = NamedTempFile::new()?;
     Generator::builder()
         .with_root_name_str(&opts.root)
         .with_input_file(&opts.schema_path)
+        .with_options(&generator_options)
         .build()
         .generate_to_file(
             &generated_file


### PR DESCRIPTION
Problem:
A server can add backwards compatible optional fields which will break the client if it fails when we parse a response because we deny unknown fields. 


Solution: Rather than remove that altogether (I assume you put it in for a good reason), I added a command line flag to prevent writing `deny_unknown_fields` to files. Plumbed this through in a more general 'options' field so further fields can be added without changing signatures in the future, or adding a large number of arguments to functions.

Without flag
```
❯ ./target/release/schemafy ActorInput.json --root ActorInput 
#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
#[serde(deny_unknown_fields)]
pub struct ActorInput {
    #[serde(skip_serializing_if = "Option::is_none")]
    pub group: Option<Vec<String>>,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub user: Option<Vec<String>>,
}
```
With flag: 
```
schemafy on  fix/allow-unknown-parameters is 📦 v0.6.0 via 🦀 v1.65.0 
❯ ./target/release/schemafy ActorInput.json --root ActorInput --allow-unknown-fields
#[derive(Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
pub struct ActorInput {
    #[serde(skip_serializing_if = "Option::is_none")]
    pub group: Option<Vec<String>>,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub user: Option<Vec<String>>,
}
```