### PR TITLE
Handle `allOf` with a single sub-schema correctly

### DIFF
--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -384,10 +384,10 @@ impl<'r> Expander<'r> {
             None => schema,
         };
         match schema.all_of {
-            Some(ref all_of) if all_of.len() == 1 => match all_of[0].ref_ {
-                Some(ref ref_) => Cow::Borrowed(self.schema_ref(ref_)),
-                None => Cow::Borrowed(&all_of[0]),
-            },
+            // Some(ref all_of) if all_of.len() == 1 => match all_of[0].ref_ {
+            //     Some(ref ref_) => Cow::Borrowed(self.schema_ref(ref_)),
+            //     None => Cow::Borrowed(&all_of[0]),
+            // },
             Some(ref all_of) if !all_of.is_empty() => {
                 all_of
                     .iter()

--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -386,7 +386,10 @@ impl<'r> Expander<'r> {
         match schema.all_of {
             Some(ref all_of) if !all_of.is_empty() => {
                 if all_of.len() == 1 {
-                    Cow::Borrowed(&all_of[0])
+                    match all_of[0].ref_ {
+                        Some(ref ref_) => Cow::Borrowed(self.schema_ref(ref_)),
+                        None => Cow::Borrowed(&all_of[0]),
+                    }
                 } else {
                     all_of.iter().skip(1).fold(
                         self.schema(&all_of[0]).clone(),

--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -526,6 +526,12 @@ impl<'r> Expander<'r> {
                 }
                 _ => "serde_json::Value".into(),
             }
+        } else if typ
+            .all_of
+            .as_ref()
+            .map_or(false, |all_of| all_of.len() == 1)
+        {
+            self.expand_type_(&typ.all_of.as_ref().unwrap()[0])
         } else {
             "serde_json::Value".into()
         }

--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -385,13 +385,17 @@ impl<'r> Expander<'r> {
         };
         match schema.all_of {
             Some(ref all_of) if !all_of.is_empty() => {
-                all_of
-                    .iter()
-                    .skip(1)
-                    .fold(self.schema(&all_of[0]).clone(), |mut result, def| {
-                        merge_all_of(result.to_mut(), &self.schema(def));
-                        result
-                    })
+                if all_of.len() == 1 {
+                    Cow::Borrowed(&all_of[0])
+                } else {
+                    all_of.iter().skip(1).fold(
+                        self.schema(&all_of[0]).clone(),
+                        |mut result, def| {
+                            merge_all_of(result.to_mut(), &self.schema(def));
+                            result
+                        },
+                    )
+                }
             }
             _ => Cow::Borrowed(schema),
         }

--- a/schemafy_lib/src/lib.rs
+++ b/schemafy_lib/src/lib.rs
@@ -384,10 +384,6 @@ impl<'r> Expander<'r> {
             None => schema,
         };
         match schema.all_of {
-            // Some(ref all_of) if all_of.len() == 1 => match all_of[0].ref_ {
-            //     Some(ref ref_) => Cow::Borrowed(self.schema_ref(ref_)),
-            //     None => Cow::Borrowed(&all_of[0]),
-            // },
             Some(ref all_of) if !all_of.is_empty() => {
                 all_of
                     .iter()


### PR DESCRIPTION
This special-cases handling of `allOf` when the `allOf` contains a single JSON schema, allowing that interior schema to become the top-level type.

Closes #75.